### PR TITLE
Get rid of the extra space between "U." and "S." on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@ layout: home
 
 {% capture slogan %}
 Help
-<span style="color:#FF2222; text-shadow: 0 0 8px rgba(255, 255, 255, 0.6); }">U</span>.
-<span style="color:#2222FF; text-shadow: 0 0 8px rgba(255, 255, 255, 0.6); }">S</span>.
+<span style="color:#FF2222; text-shadow: 0 0 8px rgba(255, 255, 255, 0.6); }">U</span>.<span style="color:#2222FF; text-shadow: 0 0 8px rgba(255, 255, 255, 0.6); }">S</span>.
 kickstart fundamental reform,<br>
 by reducing the influence of money in politics.
 {% endcapture %}


### PR DESCRIPTION
The simplest way to do this is to remove the whitespace in the source.

Turns this:

![screen shot 2014-05-15 at 9 08 05 am](https://cloud.githubusercontent.com/assets/917945/2984400/fff7b1d6-dc31-11e3-9892-9e3f39de6c98.png)

into this:

![screen shot 2014-05-15 at 9 08 12 am](https://cloud.githubusercontent.com/assets/917945/2984405/037c8c1e-dc32-11e3-9dc7-26b296ef967f.png)
